### PR TITLE
Improve dashboard UX

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,15 +1,10 @@
 "use client"
 
 import * as React from "react"
-import {
-  Map,
-  PieChart,
-  Home,
-  UserPlus,
-  Users,
-  Calendar,
-  Folder,
-} from "lucide-react"
+import Image from "next/image"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Map, PieChart, Home, UserPlus, Users, Calendar, Folder } from "lucide-react"
 
 import { NavMain } from "@/components/nav-main"
 import { NavProjects } from "@/components/nav-projects"
@@ -149,17 +144,14 @@ const data = {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   // Simular estado de usuario logueado - en una app real esto vendría de un contexto de autenticación
-  const [isLoggedIn, setIsLoggedIn] = React.useState(false)
-  const [currentUser, setCurrentUser] = React.useState<string | null>(null)
+  const [isLoggedIn, setIsLoggedIn] = React.useState(true)
 
   const handleLogout = () => {
     setIsLoggedIn(false)
-    setCurrentUser(null)
   }
 
   const handleLogin = () => {
     setIsLoggedIn(true)
-    setCurrentUser("Juan Pérez")
   }
 
   return (
@@ -168,25 +160,31 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
-              <a href="#" className="flex items-center gap-3 hover:bg-gradient-to-r hover:from-teal-50 hover:to-blue-50 rounded-lg transition-all duration-200">
-                <div className="flex aspect-square size-16 items-center justify-center rounded-lg">
-                  <img src="/infocar-logo.svg" alt="InfoCar Logo" className="size-14" />
+              <Link
+                href="/dashboard"
+                className="group flex items-center gap-3 rounded-lg transition-all duration-200 hover:bg-gradient-to-r hover:from-teal-50 hover:to-blue-50"
+              >
+                <div className="flex aspect-square size-16 items-center justify-center rounded-lg bg-white shadow-sm">
+                  <Image src="/infocar-logo.svg" alt="InfoCar Logo" width={48} height={48} />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-bold text-xl bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent">
+                  <span className="truncate text-xl font-bold text-teal-700 transition-colors group-hover:text-blue-700">
                     INFOCAR
                   </span>
-                  {!isLoggedIn && (
-                    <button 
-                      onClick={handleLogin}
-                      className="text-xs text-green-600 hover:text-green-700 text-left"
-                    >
-                      Iniciar Sesión
-                    </button>
-                  )}
+                  <span className="text-xs text-muted-foreground">Panel de control centralizado</span>
                 </div>
-              </a>
+              </Link>
             </SidebarMenuButton>
+            {!isLoggedIn && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-3 w-full text-xs"
+                onClick={handleLogin}
+              >
+                Iniciar sesión para administrar
+              </Button>
+            )}
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
@@ -196,6 +194,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarContent>
       <SidebarFooter className="bg-gradient-to-r from-teal-50 to-blue-50 border-t border-teal-200">
         <NavUser user={data.user} isLoggedIn={isLoggedIn} onLogout={handleLogout} />
+        {!isLoggedIn && (
+          <p className="px-2 pb-2 text-xs text-muted-foreground">
+            ¿Necesitas acceso? Solicita invitación desde el módulo de administración.
+          </p>
+        )}
       </SidebarFooter>
     </Sidebar>
   )

--- a/src/components/dashboard/news-section.tsx
+++ b/src/components/dashboard/news-section.tsx
@@ -1,243 +1,276 @@
-"use client";
+"use client"
 
-import React from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Clock, ArrowRight, Eye, Pin } from "lucide-react";
+import Link from "next/link"
+import Image from "next/image"
+import { ArrowRight, Pin } from "lucide-react"
 
-interface NewsItem {
-  id: number;
-  title: string;
-  summary: string;
-  category: string;
-  publishDate: string;
-  readTime: string;
-  views: number;
-  image?: string;
-  featured?: boolean;
-  isPinned?: boolean;
-  author?: string;
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+type DashboardNewsItem = {
+  id: number
+  title: string
+  excerpt: string
+  category: string
+  date: string
+  image: string
+  featured?: boolean
+  isPinned?: boolean
+  author?: string
+  href?: string
 }
 
-const newsItems: NewsItem[] = [
+const categoryStyles: Record<
+  string,
+  {
+    badge: string
+    accent: string
+    text: string
+  }
+> = {
+  Tecnología: {
+    badge: "bg-emerald-100 text-emerald-800",
+    accent: "ring-emerald-200/70",
+    text: "text-emerald-600",
+  },
+  Negocios: {
+    badge: "bg-blue-100 text-blue-800",
+    accent: "ring-blue-200/70",
+    text: "text-blue-600",
+  },
+  Mantenimiento: {
+    badge: "bg-amber-100 text-amber-800",
+    accent: "ring-amber-200/70",
+    text: "text-amber-600",
+  },
+  Finanzas: {
+    badge: "bg-violet-100 text-violet-800",
+    accent: "ring-violet-200/70",
+    text: "text-violet-600",
+  },
+}
+
+const newsData: DashboardNewsItem[] = [
   {
     id: 1,
-    title: "Nuevas Directrices de Salud Digital para 2024",
-    summary: "El Ministerio de Salud presenta las nuevas normativas para la digitalización de procesos sanitarios en centros de atención primaria.",
-    category: "Normativas",
-    publishDate: "2024-01-15",
-    readTime: "5 min",
-    views: 1250,
-    image: "https://placehold.co/400x200/3b82f6/ffffff?text=Salud+Digital",
+    title: "Nueva actualización del sistema InfoCar",
+    excerpt:
+      "Descubre las últimas funcionalidades implementadas para mejorar la gestión vehicular de tu empresa.",
+    category: "Tecnología",
+    date: "2024-01-15",
+    image: "/news-1.svg",
     featured: true,
     isPinned: true,
-    author: "Ministerio de Salud",
+    author: "Equipo InfoCar",
+    href: "/dashboard/noticias/actualizacion",
   },
   {
     id: 2,
-    title: "Actualización del Sistema de Registro de Pacientes",
-    summary: "Mejoras en la interfaz y nuevas funcionalidades para optimizar el registro y seguimiento de pacientes.",
-    category: "Tecnología",
-    publishDate: "2024-01-12",
-    readTime: "3 min",
-    views: 890,
-    image: "https://placehold.co/400x200/10b981/ffffff?text=Sistema",
-    author: "Equipo de Desarrollo",
+    title: "Mejores prácticas en gestión de flotas",
+    excerpt: "Consejos y estrategias para optimizar el rendimiento de tu flota vehicular.",
+    category: "Negocios",
+    date: "2024-01-14",
+    image: "/news-2.svg",
+    href: "/dashboard/noticias/gestion-flotas",
   },
   {
     id: 3,
-    title: "Capacitación en Nuevos Protocolos de Atención",
-    summary: "Programa de formación continua para el personal de salud en los nuevos protocolos de atención al paciente.",
-    category: "Capacitación",
-    publishDate: "2024-01-10",
-    readTime: "4 min",
-    views: 675,
-    isPinned: true,
-    author: "Departamento de Capacitación",
+    title: "Mantenimiento preventivo: clave del éxito",
+    excerpt:
+      "La importancia del mantenimiento regular para prolongar la vida útil de los vehículos.",
+    category: "Mantenimiento",
+    date: "2024-01-13",
+    image: "/news-1.svg",
+    href: "/dashboard/noticias/mantenimiento",
   },
   {
     id: 4,
-    title: "Estadísticas de Atención Primer Trimestre",
-    summary: "Análisis detallado de los indicadores de atención y satisfacción del usuario durante el primer trimestre del año.",
-    category: "Estadísticas",
-    publishDate: "2024-01-08",
-    readTime: "6 min",
-    views: 432,
-    author: "Analista de Datos",
+    title: "Análisis de costos operativos",
+    excerpt: "Cómo reducir gastos y maximizar la eficiencia en la operación vehicular.",
+    category: "Finanzas",
+    date: "2024-01-12",
+    image: "/news-2.svg",
+    href: "/dashboard/noticias/costos",
   },
-];
+]
 
-function formatDate(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('es-ES', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric'
-  });
+function formatDate(dateString: string) {
+  const date = new Date(dateString)
+  return date.toLocaleDateString("es-ES", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })
 }
 
-function getCategoryColor(category: string): string {
-  const colors: { [key: string]: string } = {
-    "Normativas": "bg-blue-100 text-blue-800",
-    "Tecnología": "bg-green-100 text-green-800",
-    "Capacitación": "bg-purple-100 text-purple-800",
-    "Estadísticas": "bg-orange-100 text-orange-800",
-  };
-  return colors[category] || "bg-gray-100 text-gray-800";
+function getCategoryBadge(category: string) {
+  return categoryStyles[category]?.badge ?? "bg-slate-100 text-slate-700"
+}
+
+function getAccentRing(category: string) {
+  return categoryStyles[category]?.accent ?? "ring-slate-200/70"
+}
+
+function getAccentText(category: string) {
+  return categoryStyles[category]?.text ?? "text-slate-600"
 }
 
 export function NewsSection() {
-  const featuredNews = [
-    {
-      id: 1,
-      title: "Nueva Actualización del Sistema InfoCar",
-      excerpt: "Descubre las últimas funcionalidades implementadas para mejorar la gestión vehicular de tu empresa.",
-      category: "Tecnología",
-      date: "2024-01-15",
-      image: "/news-1.svg",
-    },
-  ];
-
-  const regularNews = [
-    {
-      id: 2,
-      title: "Mejores Prácticas en Gestión de Flotas",
-      excerpt: "Consejos y estrategias para optimizar el rendimiento de tu flota vehicular.",
-      category: "Negocios",
-      date: "2024-01-14",
-      image: "/news-2.svg",
-    },
-    {
-      id: 3,
-      title: "Mantenimiento Preventivo: Clave del Éxito",
-      excerpt: "La importancia del mantenimiento regular para prolongar la vida útil de los vehículos.",
-      category: "Mantenimiento",
-      date: "2024-01-13",
-      image: "/news-1.svg",
-    },
-    {
-      id: 4,
-      title: "Análisis de Costos Operativos",
-      excerpt: "Cómo reducir gastos y maximizar la eficiencia en la operación vehicular.",
-      category: "Finanzas",
-      date: "2024-01-12",
-      image: "/news-2.svg",
-    },
-  ];
+  const featuredNews = newsData.filter((item) => item.featured)
+  const regularNews = newsData.filter((item) => !item.featured)
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">Noticias</h2>
-        <Button variant="outline" size="sm">
-          Ver Todas
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold">Noticias</h2>
+          <p className="text-sm text-muted-foreground">
+            Mantente al tanto de los cambios más relevantes dentro de la plataforma.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/dashboard/noticias">Ver todas</Link>
         </Button>
       </div>
 
       {/* Noticias Destacadas */}
-      <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-muted-foreground">Destacadas</h3>
-        <div className="grid gap-4 md:grid-cols-2">
-          {featuredNews.map((news) => (
-            <Card key={news.id} className={`overflow-hidden ${news.isPinned ? 'ring-2 ring-blue-500/20 bg-blue-50/50 dark:bg-blue-950/20' : ''}`}>
-              <div className="aspect-video relative">
-                <img
-                  src={news.image}
-                  alt={news.title}
-                  className="w-full h-full object-cover"
-                  onError={(e) => {
-              e.currentTarget.src = "/news-1.svg";
-            }}
-                />
-                <Badge 
-                  className="absolute top-2 left-2"
-                  style={{ backgroundColor: getCategoryColor(news.category) }}
-                >
-                  {news.category}
-                </Badge>
-                {news.isPinned && (
-                  <div className="absolute top-2 right-2 bg-blue-600 text-white p-1.5 rounded-full shadow-lg">
-                    <Pin className="h-3 w-3" />
-                  </div>
+      {featuredNews.length > 0 && (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-muted-foreground">Destacadas</h3>
+            <span className="text-xs text-muted-foreground">
+              Actualizadas cada semana
+            </span>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {featuredNews.map((news) => (
+              <Card
+                key={news.id}
+                className={cn(
+                  "overflow-hidden border border-border/60",
+                  news.isPinned && `${getAccentRing(news.category)} ring-2`
                 )}
-              </div>
-              <CardContent className="p-4">
-                <div className="space-y-2">
-                  <div className="flex items-start justify-between gap-2">
-                    <h4 className="font-semibold line-clamp-2 flex-1">{news.title}</h4>
-                    {news.isPinned && (
-                      <Badge variant="secondary" className="text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                        Anclada
-                      </Badge>
+              >
+                <div className="relative aspect-video">
+                  <Image
+                    src={news.image}
+                    alt={news.title}
+                    fill
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    className="object-cover"
+                  />
+                  <Badge
+                    className={cn(
+                      "absolute left-3 top-3",
+                      "px-3 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm",
+                      getCategoryBadge(news.category)
                     )}
+                  >
+                    {news.category}
+                  </Badge>
+                  {news.isPinned && (
+                    <div className="absolute right-3 top-3 rounded-full bg-primary px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-primary-foreground shadow-md">
+                      <span className="inline-flex items-center gap-1">
+                        <Pin className="h-3 w-3" /> Anclada
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <CardContent className="space-y-3 p-4">
+                  <div className="space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <h4 className="text-base font-semibold leading-tight text-foreground">
+                        {news.title}
+                      </h4>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{news.excerpt}</p>
                   </div>
-                  <p className="text-sm text-muted-foreground line-clamp-2">
-                    {news.excerpt}
-                  </p>
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <div className="flex flex-col gap-1">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                    <div className="flex flex-col gap-0.5">
                       <span>{formatDate(news.date)}</span>
                       {news.author && (
-                        <span className="text-blue-600 dark:text-blue-400 font-medium">
+                        <span className={cn("font-medium", getAccentText(news.category))}>
                           Por: {news.author}
                         </span>
                       )}
                     </div>
-                    <Button variant="ghost" size="sm">
-                      Leer Más
+                    <Button asChild variant="ghost" size="sm" className="h-8 px-3 text-xs">
+                      <Link href={news.href ?? "#"} aria-label={`Leer más sobre ${news.title}`}>
+                        Leer más
+                      </Link>
                     </Button>
                   </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+      )}
 
-      {/* Noticias Regulares */}
-      <div className="space-y-4">
-        <h3 className="text-lg font-semibold text-muted-foreground">Recientes</h3>
-        <div className="space-y-3">
-          {regularNews.map((news) => (
-            <Card key={news.id} className={`p-4 ${news.isPinned ? 'ring-2 ring-blue-500/20 bg-blue-50/50 dark:bg-blue-950/20' : ''}`}>
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 space-y-1">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <Badge 
-                      variant="outline"
-                      style={{ borderColor: getCategoryColor(news.category) }}
-                    >
-                      {news.category}
-                    </Badge>
-                    {news.isPinned && (
-                      <Badge variant="secondary" className="text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                        <Pin className="h-3 w-3 mr-1" />
-                        Anclada
-                      </Badge>
-                    )}
-                    <span className="text-xs text-muted-foreground">
-                      {formatDate(news.date)}
-                    </span>
+      {/* Noticias Recientes */}
+      {regularNews.length > 0 && (
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-muted-foreground">Recientes</h3>
+          <div className="space-y-3">
+            {regularNews.map((news) => (
+              <Card
+                key={news.id}
+                className={cn(
+                  "flex flex-col gap-3 rounded-xl border border-border/60 p-4 transition-colors hover:bg-muted/60",
+                  news.isPinned && `${getAccentRing(news.category)} ring-1`
+                )}
+              >
+                <div className="flex items-start gap-4">
+                  <div className="relative hidden h-16 w-20 overflow-hidden rounded-lg bg-muted sm:block">
+                    <Image
+                      src={news.image}
+                      alt="Ilustración de la noticia"
+                      fill
+                      sizes="80px"
+                      className="object-cover"
+                    />
                   </div>
-                  <h4 className="font-medium line-clamp-1">{news.title}</h4>
-                  <p className="text-sm text-muted-foreground line-clamp-2">
-                    {news.excerpt}
-                  </p>
-                  {news.author && (
-                    <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">
-                      Por: {news.author}
-                    </p>
-                  )}
+                  <div className="flex-1 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "border px-2 py-0.5 font-medium uppercase tracking-wide",
+                          getCategoryBadge(news.category)
+                        )}
+                      >
+                        {news.category}
+                      </Badge>
+                      <span className="text-muted-foreground">{formatDate(news.date)}</span>
+                      {news.author && (
+                        <span className={cn("font-medium", getAccentText(news.category))}>
+                          {news.author}
+                        </span>
+                      )}
+                    </div>
+                    <h4 className="text-sm font-semibold leading-tight text-foreground">
+                      {news.title}
+                    </h4>
+                    <p className="line-clamp-2 text-sm text-muted-foreground">{news.excerpt}</p>
+                  </div>
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="icon"
+                    className="ml-auto h-8 w-8 shrink-0"
+                  >
+                    <Link href={news.href ?? "#"} aria-label={`Ir a ${news.title}`}>
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </Button>
                 </div>
-                <Button variant="ghost" size="sm">
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
+              </Card>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
-  );
+  )
 }

--- a/src/components/dashboard/widgets.tsx
+++ b/src/components/dashboard/widgets.tsx
@@ -1,33 +1,22 @@
 "use client";
 
-import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { 
-  Users, 
-  FileText, 
-  Calendar, 
-  TrendingUp, 
-  Bell, 
-  Clock,
-  Activity,
+import {
+  Users,
+  FileText,
+  Calendar,
+  TrendingUp,
+  Bell,
   AlertCircle,
   CheckCircle2,
   Check,
   Plus,
   Search,
   Settings,
-  BarChart3
 } from "lucide-react";
-
-interface StatItem {
-  label: string;
-  value: string;
-  change?: string;
-  trend?: "up" | "down" | "neutral";
-}
 
 interface TaskItem {
   id: number;
@@ -44,13 +33,6 @@ interface NotificationItem {
   time: string;
   type: "info" | "warning" | "success";
 }
-
-const stats: StatItem[] = [
-  { label: "Pacientes Atendidos", value: "1,247", change: "+12%", trend: "up" },
-  { label: "Consultas Pendientes", value: "23", change: "-5%", trend: "down" },
-  { label: "Documentos Procesados", value: "89", change: "+8%", trend: "up" },
-  { label: "Satisfacción Usuario", value: "94%", change: "+2%", trend: "up" },
-];
 
 const todayStats = [
   { icon: Users, value: "156", label: "Usuarios Activos", color: "text-blue-600" },
@@ -89,30 +71,6 @@ const monthlyProgress = [
   { label: "Eficiencia Operativa", value: 92 },
 ];
 
-const tasks: TaskItem[] = [
-  {
-    id: 1,
-    title: "Revisar informes mensuales",
-    priority: "alta",
-    dueDate: "2024-01-16",
-    completed: false,
-  },
-  {
-    id: 2,
-    title: "Actualizar base de datos",
-    priority: "media",
-    dueDate: "2024-01-18",
-    completed: false,
-  },
-  {
-    id: 3,
-    title: "Capacitación equipo",
-    priority: "baja",
-    dueDate: "2024-01-20",
-    completed: true,
-  },
-];
-
 const notifications: NotificationItem[] = [
   {
     id: 1,
@@ -137,13 +95,29 @@ const notifications: NotificationItem[] = [
   },
 ];
 
-const getPriorityColor = (priority: string) => {
-  switch (priority) {
-    case "alta": return "text-red-600 bg-red-50";
-    case "media": return "text-yellow-600 bg-yellow-50";
-    case "baja": return "text-green-600 bg-green-50";
-    default: return "text-gray-600 bg-gray-50";
-  }
+type PriorityStyle = { badge: string; label: string }
+
+const priorityStyles: Record<TaskItem["priority"], PriorityStyle> = {
+  alta: { badge: "border-red-200 bg-red-50 text-red-700", label: "Alta" },
+  media: { badge: "border-amber-200 bg-amber-50 text-amber-700", label: "Media" },
+  baja: { badge: "border-emerald-200 bg-emerald-50 text-emerald-700", label: "Baja" },
+};
+
+const fallbackPriorityStyle: PriorityStyle = {
+  badge: "border-slate-200 bg-slate-50 text-slate-600",
+  label: "Sin prioridad",
+};
+
+const getPriorityColor = (priority: TaskItem["priority"]): PriorityStyle =>
+  priorityStyles[priority] ?? fallbackPriorityStyle;
+
+const formatDueDate = (date: string) => {
+  const parsed = new Date(date);
+  return parsed.toLocaleDateString("es-ES", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 };
 
 const getNotificationIcon = (type: string) => {
@@ -214,22 +188,26 @@ export function Widgets() {
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {pendingTasks.map((task) => (
-              <div key={task.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
-                <div className="flex-1">
-                  <p className="font-medium text-sm">{task.title}</p>
-                  <p className="text-xs text-muted-foreground">{task.dueDate}</p>
+            {pendingTasks.map((task) => {
+              const priority = getPriorityColor(task.priority);
+
+              return (
+                <div key={task.id} className="flex items-center justify-between gap-3 rounded-lg bg-muted/50 p-3">
+                  <div className="flex-1">
+                    <p className="text-sm font-medium">{task.title}</p>
+                    <p className="text-xs text-muted-foreground">Entrega: {formatDueDate(task.dueDate)}</p>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Badge className={`border text-xs capitalize ${priority.badge}`}>
+                      {priority.label}
+                    </Badge>
+                    <Button variant="ghost" size="sm" aria-label="Marcar tarea como completada">
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
-                <div className="flex items-center space-x-2">
-                  <Badge className={`text-xs ${getPriorityColor(task.priority)}`}>
-                    {task.priority}
-                  </Badge>
-                  <Button variant="ghost" size="sm">
-                    <Check className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </CardContent>
       </Card>
@@ -262,12 +240,15 @@ export function Widgets() {
         <CardContent>
           <div className="space-y-3">
             {notifications.map((notification) => (
-              <div key={notification.id} className="flex items-start space-x-3 p-3 bg-muted/50 rounded-lg">
+              <div
+                key={notification.id}
+                className="flex items-start space-x-3 rounded-lg bg-muted/50 p-3 transition-colors hover:bg-muted"
+              >
                 {getNotificationIcon(notification.type)}
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm">{notification.title}</p>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{notification.title}</p>
                   <p className="text-xs text-muted-foreground">{notification.message}</p>
-                  <p className="text-xs text-muted-foreground mt-1">{notification.time}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{notification.time}</p>
                 </div>
               </div>
             ))}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { ChevronRight, type LucideIcon } from "lucide-react"
 
 import {
@@ -18,6 +20,7 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
 
 export function NavMain({
   items,
@@ -33,45 +36,70 @@ export function NavMain({
     }[]
   }[]
 }) {
+  const pathname = usePathname()
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Pagina Principal</SidebarGroupLabel>
       <SidebarMenu>
-        {items.map((item) => (
-          <Collapsible key={item.title} asChild defaultOpen={item.isActive}>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild tooltip={item.title}>
-                <a href={item.url}>
-                  <item.icon />
-                  <span>{item.title}</span>
-                </a>
-              </SidebarMenuButton>
-              {item.items?.length ? (
-                <>
-                  <CollapsibleTrigger asChild>
-                    <SidebarMenuAction className="data-[state=open]:rotate-90">
-                      <ChevronRight />
-                      <span className="sr-only">Toggle</span>
-                    </SidebarMenuAction>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <SidebarMenuSub>
-                      {item.items?.map((subItem) => (
-                        <SidebarMenuSubItem key={subItem.title}>
-                          <SidebarMenuSubButton asChild>
-                            <a href={subItem.url}>
-                              <span>{subItem.title}</span>
-                            </a>
-                          </SidebarMenuSubButton>
-                        </SidebarMenuSubItem>
-                      ))}
-                    </SidebarMenuSub>
-                  </CollapsibleContent>
-                </>
-              ) : null}
-            </SidebarMenuItem>
-          </Collapsible>
-        ))}
+        {items.map((item) => {
+          const isActive =
+            item.isActive ?? pathname.startsWith(item.url) ||
+            item.items?.some((subItem) => pathname.startsWith(subItem.url))
+
+          return (
+            <Collapsible key={item.title} asChild defaultOpen={isActive}>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  tooltip={item.title}
+                  className={cn(isActive && "bg-sidebar-accent text-sidebar-accent-foreground")}
+                >
+                  <Link href={item.url} aria-current={isActive ? "page" : undefined}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+                {item.items?.length ? (
+                  <>
+                    <CollapsibleTrigger asChild>
+                      <SidebarMenuAction className="data-[state=open]:rotate-90">
+                        <ChevronRight />
+                        <span className="sr-only">Toggle</span>
+                      </SidebarMenuAction>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <SidebarMenuSub>
+                        {item.items?.map((subItem) => {
+                          const isSubActive = pathname.startsWith(subItem.url)
+
+                          return (
+                            <SidebarMenuSubItem key={subItem.title}>
+                              <SidebarMenuSubButton
+                                asChild
+                                className={cn(
+                                  "transition-colors",
+                                  isSubActive && "bg-sidebar-accent/60 text-sidebar-accent-foreground"
+                                )}
+                              >
+                                <Link
+                                  href={subItem.url}
+                                  aria-current={isSubActive ? "page" : undefined}
+                                >
+                                  <span>{subItem.title}</span>
+                                </Link>
+                              </SidebarMenuSubButton>
+                            </SidebarMenuSubItem>
+                          )
+                        })}
+                      </SidebarMenuSub>
+                    </CollapsibleContent>
+                  </>
+                ) : null}
+              </SidebarMenuItem>
+            </Collapsible>
+          )
+        })}
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import {
   Eye,
   Edit,
@@ -25,6 +26,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
 
 export function NavProjects({
   projects,
@@ -55,10 +57,10 @@ export function NavProjects({
         {projects.map((item) => (
           <SidebarMenuItem key={item.name}>
             <SidebarMenuButton asChild>
-              <a href={item.url}>
-                <item.icon />
+              <Link href={item.url} className="flex items-center gap-2">
+                <item.icon className="h-4 w-4" />
                 <span>{item.name}</span>
-              </a>
+              </Link>
             </SidebarMenuButton>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -73,29 +75,47 @@ export function NavProjects({
                 align={isMobile ? "end" : "start"}
               >
                 {item.actions?.view !== false && (
-                  <DropdownMenuItem onClick={() => handleAction('Ver', item.name)}>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      handleAction("Ver", item.name)
+                    }}
+                  >
                     <Eye className="text-muted-foreground" />
                     <span>Ver</span>
                   </DropdownMenuItem>
                 )}
                 {item.actions?.edit !== false && (
-                  <DropdownMenuItem onClick={() => handleAction('Editar', item.name)}>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      handleAction("Editar", item.name)
+                    }}
+                  >
                     <Edit className="text-muted-foreground" />
                     <span>Editar</span>
                   </DropdownMenuItem>
                 )}
                 {item.actions?.add !== false && (
-                  <DropdownMenuItem onClick={() => handleAction('Agregar', item.name)}>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      handleAction("Agregar", item.name)
+                    }}
+                  >
                     <Plus className="text-muted-foreground" />
                     <span>Agregar</span>
                   </DropdownMenuItem>
                 )}
-                {(item.actions?.delete !== false) && (
+                {item.actions?.delete !== false && (
                   <>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem 
-                      onClick={() => handleAction('Eliminar', item.name)}
-                      className="text-destructive focus:text-destructive"
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault()
+                        handleAction("Eliminar", item.name)
+                      }}
+                      className={cn("text-destructive focus:text-destructive")}
                     >
                       <Trash2 className="text-destructive" />
                       <span>Eliminar</span>


### PR DESCRIPTION
## Summary
- polish the sidebar header with Next.js navigation, optimized logo rendering, and contextual login messaging
- rebuild the dashboard news section with themed category styling, accessible links, and responsive imagery
- refine widgets and navigation menus to show formatted task priorities, friendlier notifications, and active state highlighting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb72d765d48327b5f074c65f06ab93